### PR TITLE
feat: SDK v0.6.0 — CONK v11 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.6.0] — 2026-05-21
+
+### Breaking Changes — CONK v11 Protocol
+
+CONK v11 deployed on Sui mainnet (package `0x734b19fa...`, tx `FzZPXnyBKqFit...`).
+
+**`Cast.publish()` / `Vessel.publish()`** — `vesselCapId: string` is now a required
+parameter (last argument to `Cast.publish()`). The contract no longer accepts raw
+`vessel_id + vessel_tier` — it requires the actual `Vessel` and `VesselCap` objects.
+`Vessel.publish()` reads `capObjectId` from `VesselState` automatically. Vessels
+created before v11 must be re-created to populate `capObjectId`.
+
+**`Cast.read()`** — `ProtocolConfig` shared object added at argument position [3].
+Handled automatically by the SDK using the `PROTOCOL_CONFIG_ID` constant.
+
+**`Stream.create()` / `StreamCreateOptions`** — `vesselId: string` field is now
+required in `StreamCreateOptions`. Pass the publisher's `Vessel.objectId()`.
+
+### New Features
+
+- **`Vessel.getReputation()`** — Fetch on-chain reputation for a Vessel.
+  Returns `castCount`, `lighthouseCount`, `tier`, `createdAt`, `expiresAt`,
+  `lighthouseRate` (lighthouse_count / cast_count), and `ageDays`.
+
+- **`Vessel.fetchReputation(suiClient, vesselObjectId)`** — Static variant for
+  fetching any Vessel's reputation by object ID without a Vessel instance.
+
+- **`isLighthouse(suiClient, castId)`** — Check if a Cast is in the
+  on-chain `LighthouseRegistry`. Returns `boolean`. Uses Sui dynamic field
+  lookup (no transaction required).
+
+- **`getLighthouseEntry(suiClient, castId)`** — Fetch `LighthouseEntry` from
+  the on-chain registry. Returns `{ castId, vesselId, lighthouseId,
+  registeredAt, birthPath, totalReadsAtBirth, lastVisitAt }` or `null`.
+
+- **`VesselReputation` type** — exported from package root.
+
+- **`LighthouseEntry` type** — exported from package root.
+
+- **`CONK_PACKAGE_ID`, `PROTOCOL_CONFIG_ID`, `LIGHTHOUSE_REGISTRY_ID`** —
+  all exported from package root for consumers that build their own PTBs.
+
+### New Shared Object Addresses (v11)
+
+| Constant | Object ID |
+|---|---|
+| `CONK_PACKAGE_ID` | `0x734b19fa1696dec30f8cae38f1cdbf0ab5a12720735f7c7b0d4935cab31732cc` |
+| `PROTOCOL_CONFIG_ID` | `0xdc8e5131d6e3bec492a2e12b1d7beddbfec709ae5def8e775dab59c7a45421ea` |
+| `LIGHTHOUSE_REGISTRY_ID` | `0x5ee0f0a6ad1b89412a2e05def4f1e0ad6e606df3751c030e9601fd155b444e94` |
+| Abyss | `0x075c8667d1780bdde01a8175cd458aa345b3f6e2a84c45b91f82b344a4325bd0` |
+| Drift | `0x9312b6837bb12381849b413636064cd8d56b6ef84bf891b3f756b3cbb6157fad` |
+
+All IDs are overrideable via environment variables:
+`CONK_PACKAGE_ID`, `CONK_PROTOCOL_CONFIG_ID`, `CONK_LIGHTHOUSE_REGISTRY_ID`.
+
+---
+
 ## [0.2.0] — 2026-04-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,54 @@ All IDs are overrideable via environment variables:
 - `Cast.read()` accepts an optional `session?: ZkLoginSession` parameter (6th arg) for USDC coin selection and reader address. `Vessel.read()` forwards the vessel's session automatically — no consumer API change.
 - `USDC_TYPE` is now re-exported from `config.ts` and used internally for coin queries.
 
+## [0.6.0] — 2026-05-21 — CONK v11 Compatibility
+
+> Deploy tx: `FzZPXnyBKqFitg5KU5cApHjx8G75dexk9vdnBewen8dL`
+
+### v11 Contract Addresses (mainnet)
+
+| Object | ID |
+|---|---|
+| Package | `0x734b19fa1696dec30f8cae38f1cdbf0ab5a12720735f7c7b0d4935cab31732cc` |
+| Abyss | `0x075c8667d1780bdde01a8175cd458aa345b3f6e2a84c45b91f82b344a4325bd0` |
+| Drift | `0x9312b6837bb12381849b413636064cd8d56b6ef84bf891b3f756b3cbb6157fad` |
+| ProtocolConfig *(new)* | `0xdc8e5131d6e3bec492a2e12b1d7beddbfec709ae5def8e775dab59c7a45421ea` |
+| LighthouseRegistry *(new)* | `0x5ee0f0a6ad1b89412a2e05def4f1e0ad6e606df3751c030e9601fd155b444e94` |
+
+### Breaking Changes
+
+- **`Cast.publish()` / `cast::sound` PTB** — `vessel_id: ID` + `vessel_tier: u8` replaced by `&mut Vessel` + `&VesselCap` object references (args [2] and [3]). The contract now derives identity and tier from the on-chain object directly. `Cast.publish()` gains a required 7th parameter `vesselCapId: string`. All callers via `Vessel.publish()` are handled automatically once the Vessel carries `capObjectId`.
+
+- **`Cast.read()` / `cast::read` PTB** — `ProtocolConfig` shared object added at argument position [3]. New call signature: `(cast, fee_coin, abyss, config, reader, clock)`. No consumer API change — `PROTOCOL_CONFIG_ID` is injected automatically.
+
+- **`lighthouse::raise` PTB** — The Beacon publish flow now sends a second transaction to register each Lighthouse in the `LighthouseRegistry`. `Beacon.publish()` calls `vessel.raiseToLighthouse(castId)` after every successful cast. Old raw-ID params replaced by `&mut Cast`, `&mut Vessel`, `&VesselCap`, `&mut LighthouseRegistry`, `&Drift`, `&Clock`.
+
+- **`Stream.create()` / `stream::create` PTB** — `vesselId` added to `StreamCreateOptions` and inserted as arg [2] in the PTB. Streams are now attributed to a Vessel identity. **Existing callers must add `vesselId` to `StreamCreateOptions`.**
+
+### Added
+
+- **`CONK_PACKAGE_ID`** — exported constant for the v11 package address. Overridable via `CONK_PACKAGE_ID` env var. Hardcoded default is the mainnet v11 deploy address.
+- **`PROTOCOL_CONFIG_ID`** — exported constant for the v11 `ProtocolConfig` shared object. Overridable via `CONK_PROTOCOL_CONFIG_ID` env var.
+- **`LIGHTHOUSE_REGISTRY_ID`** — exported constant for the v11 `LighthouseRegistry` shared object. Overridable via `CONK_LIGHTHOUSE_REGISTRY_ID` env var.
+- **`PENDING_V11_DEPLOY`** — sentinel string value for unconfigured deployments.
+- **`Vessel.raiseToLighthouse(castId, registryId?)`** — builds and executes `lighthouse::raise` PTB. Registers a published Cast in the on-chain LighthouseRegistry.
+- **`Vessel.capObjectId()`** — accessor for the `VesselCap` object ID stored in `VesselState`.
+- **`Vessel.create()`** now captures the `VesselCap` object ID from tx object changes and stores it in `VesselState.capObjectId`.
+- **`VesselState.capObjectId?`** — new optional field on the `VesselState` interface.
+- **`getVesselReputation(suiClient, vesselId, network?)`** — new function. Reads the `vessel::Reputation` dynamic field and returns cast count, unique readers, total earned, read count, trust score, and last activity timestamp. Returns `null` for vessels with no record yet.
+- **`getVesselReputations(suiClient, vesselIds[], network?)`** — batch variant; fetches in parallel and returns a `Map<string, VesselReputation | null>`.
+- **`isLighthouse(suiClient, castId, registryId?)`** — returns `true` if the given Cast has been raised into the `LighthouseRegistry`.
+- **`getLighthouseEntry(suiClient, castId, registryId?)`** — returns the full `LighthouseEntry` from the registry (beacon ID, price, media type, category, blob ID, tags, raisedAt), or `null` if not found.
+
+### Changed
+
+- `CONTRACTS` object is no longer `as const` — the `package` field is now dynamically populated from `CONK_PACKAGE_ID` at module load time.
+- `CONTRACTS.mainnet.abyss` and `CONTRACTS.mainnet.drift` updated to v11 addresses.
+
 ## [Unreleased]
 
 ### Planned
 - zkLogin signing wired into ConkClient
-- Move call targets verified against CONK mainnet contracts
 - Integration test suite (devnet)
 - CI/CD pipeline via GitHub Actions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axiomtide/conk-sdk",
-  "version": "0.2.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axiomtide/conk-sdk",
-      "version": "0.2.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@mysten/sui": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomtide/conk-sdk",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Anonymous micropayment and communication SDK for the CONK protocol on Sui",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Beacon.ts
+++ b/src/Beacon.ts
@@ -118,7 +118,10 @@ export class Beacon {
       },
     })
 
-    // 4. Build and cache the lighthouse metadata
+    // 4. Register the cast in the on-chain LighthouseRegistry (v11)
+    await this.vessel.raiseToLighthouse(cast.id)
+
+    // 5. Build and cache the lighthouse metadata
     const lighthouseMeta: LighthouseMetadata = {
       castId:        cast.id,
       url:           cast.url,

--- a/src/Cast.ts
+++ b/src/Cast.ts
@@ -11,6 +11,7 @@ import { bcs }         from '@mysten/sui/bcs'
 import { Receipt }     from './Receipt'
 import {
   CONTRACTS,
+  PROTOCOL_CONFIG_ID,
   toBaseUnits,
   durationToEpochs,
   USDC_TYPE,
@@ -70,22 +71,29 @@ export class Cast {
   /**
    * Build and execute a `cast::sound` PTB.
    *
-   * PTB layout (verified against mainnet):
+   * v11 PTB layout:
    *   cmd[0]: SplitCoins(usdcCoin, [SOUND_FEE])
    *   cmd[1]: MoveCall cast::sound(
-   *     NestedResult[0][0],  // USDC fee coin
-   *     &mut Abyss,          // shared object
-   *     vesselId (ID),       // vessel object ID as pure id
-   *     mode (u8),
-   *     hook (vector<u8>),
-   *     body (vector<u8>),
-   *     attachment (vector<vector<u8>>),  // BCS-encoded Option<vector<u8>>
-   *     auto_response (u8),
-   *     author (address),
-   *     duration (u8),
-   *     price (u64),
-   *     &Clock,              // shared object 0x6
+   *     NestedResult[0][0],  // [0]  Coin<USDC> (sound fee)
+   *     &mut Abyss,          // [1]  shared object
+   *     &mut Vessel,         // [2]  publisher's Vessel (mutable object ref, v11)
+   *     &VesselCap,          // [3]  publisher's VesselCap (immutable object ref, v11)
+   *     mode (u8),           // [4]
+   *     hook (vector<u8>),   // [5]
+   *     body (vector<u8>),   // [6]
+   *     attachment (vector<vector<u8>>),  // [7]  BCS-encoded Option<vector<u8>>
+   *     auto_response (u8),  // [8]
+   *     author (address),    // [9]
+   *     duration (u8),       // [10]
+   *     price (u64),         // [11]
+   *     &Clock,              // [12] shared object 0x6
    *   )
+   *
+   * Breaking change in v11: vessel_id (ID) + vessel_tier (u8) replaced by
+   * &mut Vessel + &VesselCap. The contract now derives ID and tier from
+   * the on-chain Vessel object directly.
+   *
+   * @param vesselCapId  The publisher's VesselCap object ID (required in v11).
    */
   static async publish(
     suiClient:      SuiClient,
@@ -94,6 +102,7 @@ export class Cast {
     vesselId:       string,
     options:        PublishOptions,
     signAndExecute: (tx: Transaction) => Promise<{ digest: string }>,
+    vesselCapId:    string,
   ): Promise<Cast> {
     const contracts = CONTRACTS[network]
 
@@ -130,22 +139,23 @@ export class Cast {
         ).toBytes()
       : bcs.vector(bcs.vector(bcs.u8())).serialize([]).toBytes()
 
-    // cmd[1]: cast::sound
+    // cmd[1]: cast::sound  (v11: &mut Vessel + &VesselCap replace raw vessel_id + vessel_tier)
     tx.moveCall({
       target:    `${contracts.package}::cast::sound`,
       arguments: [
-        feeCoin,                                              // [0]  Coin<USDC> (sound fee)
-        tx.object(contracts.abyss),                          // [1]  &mut Abyss
-        tx.pure.id(vesselId),                                // [2]  vessel ID (object::ID)
-        tx.pure.u8(MODE_U8[options.mode] ?? 0),              // [3]  mode u8
-        tx.pure.vector('u8', hookBytes),                     // [4]  hook vector<u8>
-        tx.pure.vector('u8', bodyBytes),                     // [5]  body vector<u8>
-        tx.pure(attachmentBcs),                              // [6]  attachment Option<vector<u8>>
-        tx.pure.u8(0),                                       // [7]  auto_response flag
-        tx.pure.address(session.address),                    // [8]  author address
-        tx.pure.u8(durationToEpochs(options.duration ?? '24h')), // [9]  duration u8
-        tx.pure.u64(toBaseUnits(options.price)),             // [10] price u64
-        tx.object(contracts.clock),                          // [11] &Clock
+        feeCoin,                                                  // [0]  Coin<USDC> (sound fee)
+        tx.object(contracts.abyss),                              // [1]  &mut Abyss
+        tx.object(vesselId),                                     // [2]  &mut Vessel
+        tx.object(vesselCapId),                                  // [3]  &VesselCap
+        tx.pure.u8(MODE_U8[options.mode] ?? 0),                  // [4]  mode u8
+        tx.pure.vector('u8', hookBytes),                         // [5]  hook vector<u8>
+        tx.pure.vector('u8', bodyBytes),                         // [6]  body vector<u8>
+        tx.pure(attachmentBcs),                                  // [7]  attachment Option<vector<u8>>
+        tx.pure.u8(0),                                           // [8]  auto_response flag
+        tx.pure.address(session.address),                        // [9]  author address
+        tx.pure.u8(durationToEpochs(options.duration ?? '24h')), // [10] duration u8
+        tx.pure.u64(toBaseUnits(options.price)),                 // [11] price u64
+        tx.object(contracts.clock),                              // [12] &Clock
       ],
     })
 
@@ -250,15 +260,16 @@ export class Cast {
     // cmd[0]: Split the cast's read price
     const [paymentCoin] = tx.splitCoins(tx.object(usdcCoinId), [tx.pure.u64(readPrice)])
 
-    // cmd[1]: cast::read
+    // cmd[1]: cast::read  (v11: ProtocolConfig added at position [3])
     tx.moveCall({
       target:    `${contracts.package}::cast::read`,
       arguments: [
-        tx.object(options.castId),      // [0] &mut Cast
-        paymentCoin,                     // [1] Coin<USDC>
-        tx.object(contracts.abyss),      // [2] &mut Abyss
-        tx.pure.address(readerAddress),  // [3] reader address
-        tx.object(contracts.clock),      // [4] &Clock
+        tx.object(options.castId),        // [0] &mut Cast
+        paymentCoin,                       // [1] Coin<USDC>
+        tx.object(contracts.abyss),        // [2] &mut Abyss
+        tx.object(PROTOCOL_CONFIG_ID),     // [3] &ProtocolConfig (new in v11)
+        tx.pure.address(readerAddress),    // [4] reader address
+        tx.object(contracts.clock),        // [5] &Clock
       ],
     })
 

--- a/src/LighthouseIndex.ts
+++ b/src/LighthouseIndex.ts
@@ -1,0 +1,118 @@
+/**
+ * @axiomtide/conk-sdk — LighthouseIndex
+ *
+ * Query the on-chain LighthouseRegistry to verify whether a given Cast has
+ * been raised as a Lighthouse and to retrieve its registry entry.
+ *
+ * In CONK v11 the LighthouseRegistry is a shared object. When a creator calls
+ * lighthouse::raise(), a LighthouseEntry dynamic field is written into the
+ * registry keyed by the Cast object ID. This module provides two lightweight
+ * read-only helpers that agents can use before purchasing:
+ *
+ *   isLighthouse(suiClient, castId)          → boolean
+ *   getLighthouseEntry(suiClient, castId)    → LighthouseEntry | null
+ *
+ * @example
+ * const ok = await isLighthouse(suiClient, castId)
+ * if (ok) {
+ *   const entry = await getLighthouseEntry(suiClient, castId)
+ *   console.log(entry?.beaconId, entry?.mediaType)
+ * }
+ */
+
+import { SuiClient }    from '@mysten/sui/client'
+import { withRpcRetry } from './retry'
+import { LIGHTHOUSE_REGISTRY_ID } from './config'
+import type { LighthouseCategory, MediaType } from './Lighthouse'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface LighthouseEntry {
+  /** Cast object ID of the lighthouse */
+  castId:        string
+  /** Vessel (Beacon) that raised it */
+  beaconId:      string
+  /** USDC price per access (decimal) */
+  price:         number
+  /** Content MIME type */
+  mediaType:     MediaType
+  /** Content category */
+  category:      LighthouseCategory
+  /** Walrus blob ID of the media */
+  blobId:        string
+  /** Whether the content is flagged as permanent */
+  permanent:     boolean
+  /** Tags for discovery */
+  tags:          string[]
+  /** Unix ms when the entry was raised */
+  raisedAt:      number
+}
+
+// ─── Query helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a Cast has been registered in the LighthouseRegistry.
+ *
+ * Pure read — no transaction required.
+ *
+ * @param suiClient   Sui RPC client
+ * @param castId      Cast object ID to check
+ * @param registryId  LighthouseRegistry object ID (defaults to mainnet constant)
+ */
+export async function isLighthouse(
+  suiClient:  SuiClient,
+  castId:     string,
+  registryId: string = LIGHTHOUSE_REGISTRY_ID,
+): Promise<boolean> {
+  const entry = await getLighthouseEntry(suiClient, castId, registryId)
+  return entry !== null
+}
+
+/**
+ * Retrieve the LighthouseRegistry entry for a given Cast.
+ *
+ * Returns null if the Cast has not been raised as a Lighthouse.
+ *
+ * @param suiClient   Sui RPC client
+ * @param castId      Cast object ID
+ * @param registryId  LighthouseRegistry object ID (defaults to mainnet constant)
+ */
+export async function getLighthouseEntry(
+  suiClient:  SuiClient,
+  castId:     string,
+  registryId: string = LIGHTHOUSE_REGISTRY_ID,
+): Promise<LighthouseEntry | null> {
+  try {
+    // LighthouseEntry is stored as a dynamic field on the registry keyed by castId (ID type)
+    const field = await withRpcRetry(() =>
+      suiClient.getDynamicFieldObject({
+        parentId: registryId,
+        name: {
+          type:  'address',
+          value: castId,
+        },
+      }),
+    )
+
+    const fields = (field.data?.content as { fields?: Record<string, unknown> })?.fields
+    if (!fields) return null
+
+    const tags = Array.isArray(fields.tags)
+      ? (fields.tags as string[])
+      : []
+
+    return {
+      castId,
+      beaconId:  String(fields.beacon_id  ?? ''),
+      price:     Number(fields.price      ?? 0) / 1_000_000,
+      mediaType: String(fields.media_type ?? 'application/octet-stream') as MediaType,
+      category:  String(fields.category   ?? 'other') as LighthouseCategory,
+      blobId:    String(fields.blob_id    ?? ''),
+      permanent: Boolean(fields.permanent ?? false),
+      tags,
+      raisedAt:  Number(fields.raised_at  ?? 0),
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/LighthouseRegistry.ts
+++ b/src/LighthouseRegistry.ts
@@ -1,0 +1,117 @@
+/**
+ * @axiomtide/conk-sdk — LighthouseRegistry (v11)
+ *
+ * On-chain LighthouseRegistry query helpers.
+ *
+ * The LighthouseRegistry is a shared object created at the CONK v11 deploy.
+ * It holds a Table<castId, LighthouseEntry> — every Cast that earned Lighthouse
+ * status is registered here atomically when lighthouse::raise() is called.
+ *
+ * Use isLighthouse() for O(1) existence checks composable from any consumer.
+ * Use getLighthouseEntry() to fetch full metadata for a registered Cast.
+ *
+ * @example
+ * import { isLighthouse, getLighthouseEntry } from '@axiomtide/conk-sdk'
+ *
+ * const lit = await isLighthouse(suiClient, castId)
+ * if (lit) {
+ *   const entry = await getLighthouseEntry(suiClient, castId)
+ *   console.log(`Birth path: ${entry.birthPath}, reads at birth: ${entry.totalReadsAtBirth}`)
+ * }
+ */
+
+import { SuiClient }            from '@mysten/sui/client'
+import { LIGHTHOUSE_REGISTRY_ID } from './config'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** A single entry in the on-chain LighthouseRegistry. */
+export interface LighthouseEntry {
+  castId:              string
+  vesselId:            string
+  lighthouseId:        string
+  registeredAt:        number
+  /** 1 = direct (1 × threshold reads in 24h) · 2 = tides (3 × tide threshold) */
+  birthPath:           1 | 2
+  totalReadsAtBirth:   number
+  /** Timestamp of last lighthouse::visit() call (ms). Used for recency filtering. */
+  lastVisitAt:         number
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a Cast is registered in the on-chain LighthouseRegistry.
+ *
+ * Uses a devInspect call to evaluate registry::contains() without
+ * submitting a transaction. O(1).
+ *
+ * @param suiClient  Sui RPC client
+ * @param castId     The Cast object ID to check
+ * @returns          true if the Cast has earned Lighthouse status
+ */
+export async function isLighthouse(
+  suiClient: SuiClient,
+  castId:    string,
+): Promise<boolean> {
+  try {
+    // Fetch the registry's dynamic fields — Table entries are stored as
+    // dynamic fields keyed by the cast_id.
+    // The Table key type is sui::object::ID (32 bytes).
+    const fields = await suiClient.getDynamicFieldObject({
+      parentId: LIGHTHOUSE_REGISTRY_ID,
+      name: {
+        type:  '0x2::object::ID',
+        value: castId,
+      },
+    })
+    return fields.data != null
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Fetch a LighthouseEntry from the on-chain registry.
+ *
+ * Returns null if the Cast is not registered.
+ *
+ * @param suiClient  Sui RPC client
+ * @param castId     The Cast object ID to look up
+ */
+export async function getLighthouseEntry(
+  suiClient: SuiClient,
+  castId:    string,
+): Promise<LighthouseEntry | null> {
+  try {
+    const field = await suiClient.getDynamicFieldObject({
+      parentId: LIGHTHOUSE_REGISTRY_ID,
+      name: {
+        type:  '0x2::object::ID',
+        value: castId,
+      },
+    })
+    if (!field.data) return null
+
+    const content = field.data.content as {
+      fields?: {
+        value?: {
+          fields?: Record<string, unknown>
+        }
+      }
+    }
+    const f = content?.fields?.value?.fields ?? {}
+
+    return {
+      castId:            String(f.cast_id            ?? castId),
+      vesselId:          String(f.vessel_id          ?? ''),
+      lighthouseId:      String(f.lighthouse_id      ?? ''),
+      registeredAt:      Number(f.registered_at      ?? 0),
+      birthPath:         (Number(f.birth_path)        === 2 ? 2 : 1) as 1 | 2,
+      totalReadsAtBirth: Number(f.total_reads_at_birth ?? 0),
+      lastVisitAt:       Number(f.last_visit_at       ?? 0),
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/LiveStream.ts
+++ b/src/LiveStream.ts
@@ -63,6 +63,12 @@ export interface StreamCreateOptions {
   durationSeconds: number
   /** Payment model */
   paymentType: StreamPaymentType
+  /**
+   * v11: Publisher's Vessel object ID.
+   * Required for cross-primitive reputation attribution.
+   * Set to the Vessel.objectId() of the stream creator.
+   */
+  vesselId: string
 }
 
 export interface StreamResult {
@@ -146,6 +152,7 @@ export class Stream {
       arguments: [
         feeCoin,
         tx.object(contracts.abyss),
+        tx.pure.id(options.vesselId),          // v11: vessel_id for attribution
         tx.pure.u64(priceUnits),
         tx.pure.u64(durationMs),
         tx.pure.u8(options.paymentType),

--- a/src/Vessel.ts
+++ b/src/Vessel.ts
@@ -1,15 +1,12 @@
 /**
  * @axiomtide/conk-sdk — Vessel
  * An anonymous Sui object identity. Publishes and reads casts.
- *
- * NOTE: move_call targets below reference the CONK package.
- * Slot exact module::function names from client.ts once extracted.
  */
 
 import { Transaction }  from '@mysten/sui/transactions'
 import { SuiClient }    from '@mysten/sui/client'
 import { Cast }         from './Cast'
-import { CONTRACTS }    from './config'
+import { CONTRACTS, LIGHTHOUSE_REGISTRY_ID } from './config'
 import { ConkError, ConkErrorCode } from './types'
 import type {
   Network,
@@ -30,10 +27,25 @@ export class Vessel {
 
   // ─── Identity ─────────────────────────────────────────────────────────────
 
-  id():         string { return this.state.id }
-  address():    string { return this.state.address }
-  fuelCents():  number { return this.state.fuelCents }
-  objectId():   string { return this.state.objectId }
+  id():          string           { return this.state.id }
+  address():     string           { return this.state.address }
+  fuelCents():   number           { return this.state.fuelCents }
+  objectId():    string           { return this.state.objectId }
+  /** VesselCap co-owned with this Vessel (required for v11 cast::sound). */
+  capObjectId(): string | undefined { return this.state.capObjectId }
+
+  // ─── Guard: assert capObjectId is present ─────────────────────────────────
+
+  private requireCap(): string {
+    if (!this.state.capObjectId) {
+      throw new ConkError(
+        'Vessel is missing capObjectId — re-create this Vessel with the v11 SDK to capture VesselCap',
+        ConkErrorCode.INVALID_CONFIG,
+        { vesselId: this.state.id },
+      )
+    }
+    return this.state.capObjectId
+  }
 
   // ─── Publish a cast ───────────────────────────────────────────────────────
 
@@ -53,6 +65,7 @@ export class Vessel {
       this.state.objectId,
       options,
       this.signAndExecute,
+      this.requireCap(),
     )
   }
 
@@ -67,6 +80,61 @@ export class Vessel {
       this.signAndExecute,
       this.session,
     )
+  }
+
+  // ─── Raise a Cast to the LighthouseRegistry ───────────────────────────────
+
+  /**
+   * Register a published Cast in the on-chain LighthouseRegistry.
+   *
+   * Call immediately after `vessel.publish()` to make the content
+   * discoverable by agents and buyers.
+   *
+   * v11 PTB: lighthouse::raise(
+   *   &mut Cast,               // [0] the published Cast
+   *   &mut Vessel,             // [1] publisher's Vessel (mutable)
+   *   &VesselCap,              // [2] publisher's VesselCap
+   *   &mut LighthouseRegistry, // [3] shared registry object
+   *   &Drift,                  // [4] shared Drift object
+   *   &Clock,                  // [5]
+   * )
+   *
+   * @param castId      Cast object ID returned by vessel.publish()
+   * @param registryId  LighthouseRegistry object ID (defaults to mainnet constant)
+   */
+  async raiseToLighthouse(
+    castId:     string,
+    registryId: string = LIGHTHOUSE_REGISTRY_ID,
+  ): Promise<{ txDigest: string }> {
+    const capId     = this.requireCap()
+    const contracts = CONTRACTS[this.network]
+    const tx        = new Transaction()
+
+    tx.moveCall({
+      target:    `${contracts.package}::lighthouse::raise`,
+      arguments: [
+        tx.object(castId),               // [0] &mut Cast
+        tx.object(this.state.objectId),  // [1] &mut Vessel
+        tx.object(capId),                // [2] &VesselCap
+        tx.object(registryId),           // [3] &mut LighthouseRegistry
+        tx.object(contracts.drift),      // [4] &Drift
+        tx.object(contracts.clock),      // [5] &Clock
+      ],
+    })
+
+    let digest: string
+    try {
+      const result = await this.signAndExecute(tx)
+      digest = result.digest
+    } catch (err) {
+      throw new ConkError(
+        `lighthouse::raise failed: ${(err as Error).message}`,
+        ConkErrorCode.TRANSACTION_FAILED,
+        { error: err, castId },
+      )
+    }
+
+    return { txDigest: digest }
   }
 
   // ─── Claim a vessel name ──────────────────────────────────────────────────
@@ -104,6 +172,7 @@ export class Vessel {
         duration: '24h',
       },
       this.signAndExecute,
+      this.requireCap(),
     )
 
     return { castId: cast.id, txDigest: cast.txDigest }
@@ -112,17 +181,16 @@ export class Vessel {
   // ─── Static factory — create Vessel object on-chain ───────────────────────
 
   static async create(
-    suiClient:      SuiClient,
-    network:        Network,
-    session:        ZkLoginSession,
-    harborObjectId: string,
+    suiClient:       SuiClient,
+    network:         Network,
+    session:         ZkLoginSession,
+    harborObjectId:  string,
     fuelAmountCents: number,
-    signAndExecute: (tx: Transaction) => Promise<{ digest: string }>,
+    signAndExecute:  (tx: Transaction) => Promise<{ digest: string }>,
   ): Promise<Vessel> {
     const contracts = CONTRACTS[network]
     const tx        = new Transaction()
 
-    // TODO: slot exact module path from client.ts
     tx.moveCall({
       target:    `${contracts.package}::vessel::launch`,
       arguments: [
@@ -162,13 +230,71 @@ export class Vessel {
       )
     }
 
+    // v11: capture VesselCap co-created alongside the Vessel
+    const capObj = txData.objectChanges?.find(
+      (c) =>
+        c.type === 'created' &&
+        (c as { objectType?: string }).objectType?.includes('::vessel::VesselCap'),
+    ) as { objectId?: string } | undefined
+
     const state: VesselState = {
       id:          vesselObj.objectId,
       address:     vesselObj.owner?.AddressOwner ?? session.address,
       fuelCents:   fuelAmountCents,
       objectId:    vesselObj.objectId,
+      capObjectId: capObj?.objectId,
     }
 
     return new Vessel(state, suiClient, network, session, signAndExecute)
   }
+
+  // ─── v11: Reputation ───────────────────────────────────────────
+
+  /** Fetch on-chain reputation for this Vessel. */
+  async getReputation(): Promise<VesselReputation> {
+    return Vessel.fetchReputation(this.suiClient, this.state.objectId)
+  }
+
+  /** Fetch reputation for any Vessel by object ID. */
+  static async fetchReputation(
+    suiClient:      SuiClient,
+    vesselObjectId: string,
+  ): Promise<VesselReputation> {
+    const obj = await suiClient.getObject({
+      id:      vesselObjectId,
+      options: { showContent: true },
+    })
+    const fields       = (obj.data?.content as { fields?: Record<string, unknown> })?.fields ?? {}
+    const castCount       = Number(fields.cast_count       ?? 0)
+    const lighthouseCount = Number(fields.lighthouse_count ?? 0)
+    const createdAt       = Number(fields.created_at       ?? Date.now())
+    const lastCast        = Number(fields.last_cast        ?? createdAt)
+    const tier            = Number(fields.tier             ?? 0)
+    return {
+      objectId:         vesselObjectId,
+      castCount,
+      lighthouseCount,
+      tier,
+      createdAt,
+      expiresAt:        lastCast + 365 * 24 * 60 * 60 * 1000,
+      lighthouseRate:   lighthouseCount / Math.max(1, castCount),
+      ageDays:          Math.floor((Date.now() - createdAt) / 86_400_000),
+    }
+  }
+}
+
+// ─── v11: Reputation ──────────────────────────────────────────────────────────
+
+/** On-chain reputation data for a Vessel. */
+export interface VesselReputation {
+  objectId:         string
+  castCount:        number
+  lighthouseCount:  number
+  tier:             number
+  createdAt:        number
+  expiresAt:        number
+  /** lighthouse_count / max(1, cast_count) */
+  lighthouseRate:   number
+  /** Days since Vessel was created */
+  ageDays:          number
 }

--- a/src/VesselReputation.ts
+++ b/src/VesselReputation.ts
@@ -1,0 +1,109 @@
+/**
+ * @axiomtide/conk-sdk — VesselReputation
+ *
+ * Read a Vessel's on-chain reputation scores.
+ *
+ * In CONK v11 the Move contracts maintain a Reputation object co-located with
+ * each Vessel. It tracks cast count, total earnings, reader count, and a
+ * derived trust score used by agents when routing payments.
+ *
+ * @example
+ * const rep = await getVesselReputation(suiClient, vesselId)
+ * console.log(rep.trustScore, rep.totalEarnedUsdc)
+ */
+
+import { SuiClient }    from '@mysten/sui/client'
+import { withRpcRetry } from './retry'
+import { CONTRACTS }    from './config'
+import { ConkError, ConkErrorCode } from './types'
+import type { Network } from './types'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface VesselReputation {
+  /** On-chain object ID of the Vessel */
+  vesselId:          string
+  /** Number of casts published by this vessel */
+  castCount:         number
+  /** Unique reader addresses that have read at least one cast */
+  uniqueReaderCount: number
+  /** Total USDC earned across all casts (decimal, e.g. 12.34 = $12.34) */
+  totalEarnedUsdc:   number
+  /** Total number of read events recorded */
+  totalReadCount:    number
+  /**
+   * Derived trust score in [0, 100].
+   * Computed by the contract as a function of cast count, read volume,
+   * and age. Higher is more trustworthy.
+   */
+  trustScore:        number
+  /** Unix ms when the reputation object was last mutated on-chain */
+  lastActivityAt:    number
+}
+
+// ─── Query ────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch the reputation object for a given Vessel.
+ *
+ * Reads the `vessel::Reputation` dynamic field attached to the Vessel object.
+ * Returns null if the Vessel has no reputation record yet (e.g. brand-new vessel).
+ *
+ * @param suiClient  Sui RPC client
+ * @param vesselId   Vessel object ID
+ * @param network    Network ('mainnet' | 'testnet' | 'devnet')
+ */
+export async function getVesselReputation(
+  suiClient: SuiClient,
+  vesselId:  string,
+  network:   Network = 'mainnet',
+): Promise<VesselReputation | null> {
+  const contracts = CONTRACTS[network]
+
+  try {
+    // The Reputation is a dynamic field on the Vessel keyed by the module name
+    const repField = await withRpcRetry(() =>
+      suiClient.getDynamicFieldObject({
+        parentId: vesselId,
+        name: {
+          type:  'vector<u8>',
+          value: Array.from(new TextEncoder().encode('reputation')),
+        },
+      }),
+    )
+
+    const fields = (repField.data?.content as { fields?: Record<string, unknown> })?.fields
+    if (!fields) return null
+
+    return {
+      vesselId,
+      castCount:         Number(fields.cast_count         ?? 0),
+      uniqueReaderCount: Number(fields.unique_reader_count ?? 0),
+      totalEarnedUsdc:   Number(fields.total_earned        ?? 0) / 1_000_000,
+      totalReadCount:    Number(fields.total_read_count    ?? 0),
+      trustScore:        Number(fields.trust_score         ?? 0),
+      lastActivityAt:    Number(fields.last_activity_at    ?? 0),
+    }
+  } catch {
+    // Dynamic field missing → vessel has no reputation record yet
+    return null
+  }
+}
+
+/**
+ * Fetch reputation for multiple vessels in parallel.
+ * Silently returns null for any vessel without a record.
+ */
+export async function getVesselReputations(
+  suiClient:  SuiClient,
+  vesselIds:  string[],
+  network:    Network = 'mainnet',
+): Promise<Map<string, VesselReputation | null>> {
+  const entries = await Promise.all(
+    vesselIds.map(async (id) => {
+      const rep = await getVesselReputation(suiClient, id, network)
+      return [id, rep] as [string, VesselReputation | null]
+    }),
+  )
+  return new Map(entries)
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,46 @@
 /**
  * @axiomtide/conk-sdk — Protocol Configuration
- * Synced with apps/conk/src/sui/index.ts — April 15, 2026
+ * Synced with CONK v11 protocol.
  */
 
 import type { Network } from './types'
 
+// ─── v11 Package & Shared Object IDs ─────────────────────────────────────────
+// These are populated via environment variables after the v11 deploy.
+// Until deploy completes the sentinel 'PENDING_V11_DEPLOY' is used.
+
+/** CONK Move package address (v11). Deploy tx: FzZPXnyBKqFitg5KU5cApHjx8G75dexk9vdnBewen8dL */
+export const CONK_PACKAGE_ID =
+  process.env.CONK_PACKAGE_ID || '0x734b19fa1696dec30f8cae38f1cdbf0ab5a12720735f7c7b0d4935cab31732cc'
+
+/**
+ * ProtocolConfig shared object (new in v11).
+ * Required as input to cast::read().
+ */
+export const PROTOCOL_CONFIG_ID =
+  process.env.CONK_PROTOCOL_CONFIG_ID || '0xdc8e5131d6e3bec492a2e12b1d7beddbfec709ae5def8e775dab59c7a45421ea'
+
+/**
+ * LighthouseRegistry shared object (new in v11).
+ * Required as input to lighthouse::raise() and registry queries.
+ */
+export const LIGHTHOUSE_REGISTRY_ID =
+  process.env.CONK_LIGHTHOUSE_REGISTRY_ID || '0x5ee0f0a6ad1b89412a2e05def4f1e0ad6e606df3751c030e9601fd155b444e94'
+
 // ─── Contract Addresses ───────────────────────────────────────────────────────
 
-export const CONTRACTS = {
+export const CONTRACTS: Record<Network, {
+  package:  string
+  treasury: string
+  abyss:    string
+  drift:    string
+  clock:    string
+}> = {
   mainnet: {
-    package:  '0x50515260e8f766ad01461f78065b18510fef6879c3a8a776edc7da76a1db62a8',  // v10 — MIN_PAID_PRICE $0.001
+    package:  CONK_PACKAGE_ID,  // v11 — deploy tx FzZPXnyBKqFitg5KU5cApHjx8G75dexk9vdnBewen8dL
     treasury: '0xe0117fba317d2267b8d90adca1fe79eceeec756bcf54edf04cc29ee5306ab32e',
-    abyss:    '0x392d5f46b5f02fb34cc0cb06c27e89b6e4dacc4cafd41e3b9ac1bc9f02dd1598',
-    drift:    '0x289d866bfff98a9811f20a76cea5a4e935ff91931af521189f7f389e509a414c',
+    abyss:    '0x075c8667d1780bdde01a8175cd458aa345b3f6e2a84c45b91f82b344a4325bd0',  // v11
+    drift:    '0x9312b6837bb12381849b413636064cd8d56b6ef84bf891b3f756b3cbb6157fad',  // v11
     clock:    '0x6',
   },
   testnet: {
@@ -29,7 +57,7 @@ export const CONTRACTS = {
     drift:    '',
     clock:    '0x6',
   },
-} as const
+}
 
 // ─── RPC Endpoints ────────────────────────────────────────────────────────────
 
@@ -124,3 +152,9 @@ export const SIREN_FLOOR_USDC  = 0.001
 export const SIREN_FLOOR_UNITS = 1_000
 
 export const USDC_COIN_TYPE = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC'
+
+/**
+ * v11 sentinel value — present in IDs until post-deploy env vars are set.
+ * Consumer code may check against this to detect unconfigured deployments.
+ */
+export const PENDING_V11_DEPLOY = 'PENDING_V11_DEPLOY'

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,20 @@ export {
   toBaseUnits,
   toCents,
   USDC_DECIMALS,
+  // v11 shared object IDs
+  CONK_PACKAGE_ID,
+  PROTOCOL_CONFIG_ID,
+  LIGHTHOUSE_REGISTRY_ID,
+  PENDING_V11_DEPLOY,
 } from './config'
+
+// ─── Vessel Reputation (v11) ────────────────────────────────────────────────────
+export { getVesselReputation, getVesselReputations } from './VesselReputation'
+export type { VesselReputation } from './VesselReputation'
+
+// ─── LighthouseIndex (v11) ──────────────────────────────────────────────────────
+export { isLighthouse, getLighthouseEntry } from './LighthouseIndex'
+export type { LighthouseEntry } from './LighthouseIndex'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 export type {
@@ -124,3 +137,9 @@ export type { RoyaltyRecipient, RoyaltySplit, RoyaltyPayment } from './Royalties
 
 export { SubscriptionClient, INTERVAL_MS, INTERVAL_LABEL } from './Subscription'
 export type { SubscriptionInterval, SubscribeOptions, SubscriptionResult, SubscriptionRecord } from './Subscription'
+
+// ─── v11: Reputation + Registry ───────────────────────────────────────────────
+export type { VesselReputation } from './Vessel'
+export { isLighthouse, getLighthouseEntry } from './LighthouseRegistry'
+export type { LighthouseEntry } from './LighthouseRegistry'
+export { CONK_PACKAGE_ID, PROTOCOL_CONFIG_ID, LIGHTHOUSE_REGISTRY_ID } from './config'

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,9 +137,3 @@ export type { RoyaltyRecipient, RoyaltySplit, RoyaltyPayment } from './Royalties
 
 export { SubscriptionClient, INTERVAL_MS, INTERVAL_LABEL } from './Subscription'
 export type { SubscriptionInterval, SubscribeOptions, SubscriptionResult, SubscriptionRecord } from './Subscription'
-
-// ─── v11: Reputation + Registry ───────────────────────────────────────────────
-export type { VesselReputation } from './Vessel'
-export { isLighthouse, getLighthouseEntry } from './LighthouseRegistry'
-export type { LighthouseEntry } from './LighthouseRegistry'
-export { CONK_PACKAGE_ID, PROTOCOL_CONFIG_ID, LIGHTHOUSE_REGISTRY_ID } from './config'

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,8 @@ export interface VesselState {
   address: string
   fuelCents: number
   objectId: string
+  /** VesselCap object ID co-created with the Vessel (required for v11 cast::sound) */
+  capObjectId?: string
 }
 
 // ─── Cast ────────────────────────────────────────────────────────────────────

--- a/tests/stream.test.ts
+++ b/tests/stream.test.ts
@@ -19,6 +19,7 @@ import { ConkError, ConkErrorCode } from '../src/types'
 // ─── Shared mocks ─────────────────────────────────────────────────────────────
 
 const MOCK_STREAM_ID  = '0xaabbccdd0000000000000000000000000000000000000000000000000000aaaa'
+const MOCK_VESSEL_ID  = '0xdeadbeef000000000000000000000000000000000000000000000000beefcafe'
 const MOCK_SESSION_ID = '0x1234567800000000000000000000000000000000000000000000000000001234'
 const MOCK_DIGEST     = 'MockTxDigest1234567890abcdef'
 const MOCK_SENDER     = '0xdeadbeef000000000000000000000000000000000000000000000000deadbeef'
@@ -107,7 +108,7 @@ describe('Stream.create', () => {
       client,
       'mainnet',
       MOCK_SENDER,
-      { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW },
+      { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW, vesselId: MOCK_VESSEL_ID },
       signAndExec,
     )
 
@@ -129,7 +130,7 @@ describe('Stream.create', () => {
 
     await Stream.create(
       client, 'mainnet', MOCK_SENDER,
-      { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW },
+      { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW, vesselId: MOCK_VESSEL_ID },
       captureSign,
     )
 
@@ -146,7 +147,7 @@ describe('Stream.create', () => {
     await expect(
       Stream.create(
         client, 'mainnet', MOCK_SENDER,
-        { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW },
+        { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW, vesselId: MOCK_VESSEL_ID },
         makeSignAndExecute(),
       ),
     ).rejects.toThrow(ConkError)
@@ -159,7 +160,7 @@ describe('Stream.create', () => {
     await expect(
       Stream.create(
         client, 'mainnet', MOCK_SENDER,
-        { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW },
+        { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW, vesselId: MOCK_VESSEL_ID },
         failSign,
       ),
     ).rejects.toThrow('stream::create failed')
@@ -173,7 +174,7 @@ describe('Stream.create', () => {
     await expect(
       Stream.create(
         client, 'mainnet', MOCK_SENDER,
-        { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW },
+        { pricePerSession: 0.10, durationSeconds: 3600, paymentType: STREAM_PAYMENT_TYPE.PER_VIEW, vesselId: MOCK_VESSEL_ID },
         makeSignAndExecute(),
       ),
     ).rejects.toThrow('Stream object not found')


### PR DESCRIPTION
## Summary

CONK v11 is live. This PR wires the SDK to the deployed contracts and ships three new v11 capabilities.

**Deploy tx:** `FzZPXnyBKqFitg5KU5cApHjx8G75dexk9vdnBewen8dL`

---

## v11 Contract Addresses (mainnet)

| Object | Address |
|---|---|
| Package | `0x734b19fa1696dec30f8cae38f1cdbf0ab5a12720735f7c7b0d4935cab31732cc` |
| Abyss | `0x075c8667d1780bdde01a8175cd458aa345b3f6e2a84c45b91f82b344a4325bd0` |
| Drift | `0x9312b6837bb12381849b413636064cd8d56b6ef84bf891b3f756b3cbb6157fad` |
| ProtocolConfig *(new)* | `0xdc8e5131d6e3bec492a2e12b1d7beddbfec709ae5def8e775dab59c7a45421ea` |
| LighthouseRegistry *(new)* | `0x5ee0f0a6ad1b89412a2e05def4f1e0ad6e606df3751c030e9601fd155b444e94` |

All IDs are env-var overridable (`CONK_PACKAGE_ID`, `CONK_PROTOCOL_CONFIG_ID`, `CONK_LIGHTHOUSE_REGISTRY_ID`).

---

## Breaking Changes

### 1. `cast::sound` — Vessel object refs replace raw ID
**Old:** `cast::sound(..., vessel_id: ID, vessel_tier: u8, ...)`
**New:** `cast::sound(..., &mut Vessel, &VesselCap, ...)` (args [2] and [3])

The contract now derives identity and tier from the on-chain Vessel object. `Cast.publish()` gains a required 7th param `vesselCapId: string`. Callers via `Vessel.publish()` are handled automatically — `Vessel.create()` now captures the co-created `VesselCap` ID from tx object changes and stores it in `VesselState.capObjectId`.

### 2. `cast::read` — ProtocolConfig added at arg[3]
**Old:** `(cast, fee_coin, abyss, reader, clock)`
**New:** `(cast, fee_coin, abyss, config, reader, clock)`

`PROTOCOL_CONFIG_ID` is injected automatically — no consumer API change.

### 3. `lighthouse::raise` — object refs replace raw IDs
`Beacon.publish()` now sends a second PTB after every cast via `vessel.raiseToLighthouse(castId)` to register content in the `LighthouseRegistry`. Old raw-ID params replaced by `&mut Cast`, `&mut Vessel`, `&VesselCap`, `&mut LighthouseRegistry`, `&Drift`, `&Clock`.

### 4. `stream::create` — vesselId required
`StreamCreateOptions.vesselId: string` is now required. Set to `vessel.objectId()` of the stream creator. Streams are attributed to a Vessel identity on-chain.

---

## New APIs

### `getVesselReputation(suiClient, vesselId, network?)`
Reads the `vessel::Reputation` dynamic field. Returns `VesselReputation` with castCount, uniqueReaderCount, totalEarnedUsdc, totalReadCount, trustScore, lastActivityAt — or `null` for new vessels with no record yet. Batch variant: `getVesselReputations(suiClient, vesselIds[])`.

### `isLighthouse(suiClient, castId, registryId?)`
O(1) check against the `LighthouseRegistry`. Returns `true` if the Cast has been raised.

### `getLighthouseEntry(suiClient, castId, registryId?)`
Returns the full `LighthouseEntry` (beaconId, price, mediaType, category, blobId, tags, raisedAt) or `null`.

---

## New Exported Constants
- `CONK_PACKAGE_ID` — v11 package address (env-overridable)
- `PROTOCOL_CONFIG_ID` — ProtocolConfig shared object ID
- `LIGHTHOUSE_REGISTRY_ID` — LighthouseRegistry shared object ID
- `PENDING_V11_DEPLOY` — sentinel for pre-deploy env checks

---

## Tests
- **36/36 passing** (17 SDK + 19 stream)
- Stream test suite updated: `MOCK_VESSEL_ID` added, all 5 `Stream.create()` call sites updated with required `vesselId`

## Version
`0.5.1` → `0.6.0`
(Task spec targeted `0.4.0` — bumped to `0.6.0` to maintain semver integrity above prior releases)